### PR TITLE
[Debug] Fix the bug translated text elements has 'NoneType’ object

### DIFF
--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -290,6 +290,7 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
 
 def get_text_from_page_source(html: str) -> str:
     soup = BeautifulSoup(html, features='lxml')
+    print(soup)
     target_elem = soup.find(class_="lmt__translations_as_text__text_btn")
     text = target_elem.text
     text = ' '.join(text.split())

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -263,7 +263,7 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
     
 
     # url作成
-    url = 'https://www.deepl.com/translator#' \
+    url = 'https://www.deepl.com/en/translator#' \
         + from_lang + '/' + to_lang + '/' + from_text
 
     driver.get(url)

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -272,6 +272,7 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
     for i in range(50):
         # 指定時間待つ
         time.sleep(sleep_time)
+        print(driver.find_element_by_class_name("lmt__translations_as_text__text_btn"))
         html = driver.page_source
         to_text = get_text_from_page_source(html)
 
@@ -290,7 +291,6 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
 
 def get_text_from_page_source(html: str) -> str:
     soup = BeautifulSoup(html, features='lxml')
-    print(soup)
     target_elem = soup.find(class_="lmt__translations_as_text__text_btn")
     text = target_elem.text
     text = ' '.join(text.split())

--- a/src/carrier_owl.py
+++ b/src/carrier_owl.py
@@ -263,7 +263,7 @@ def get_translated_text(from_lang: str, to_lang: str, from_text: str, driver) ->
     
 
     # url作成
-    url = 'https://www.deepl.com/en/translator#' \
+    url = 'https://www.deepl.com/translator#' \
         + from_lang + '/' + to_lang + '/' + from_text
 
     driver.get(url)


### PR DESCRIPTION
# Issue
Sometimes, the workflow stops when target_elem.text is called, and Error `AttributeError: 'NoneType' object has no attribute 'text'` occurs.

# Solution
I add the function to check the element is already enable. The reason I print the element is to ensure the element has value in ci.
https://github.com/YoshiInTokyo/Carrier-Owl/blob/68509812ca3634f6bcc3c892b66f233ae468f7ff/src/carrier_owl.py#L275
